### PR TITLE
fix: Updates the path of authentication cookies to “/api/vtexid/refreshtoken/webstore” in refreshToken and setLoginCookies.

### DIFF
--- a/vtex/actions/authentication/refreshToken.ts
+++ b/vtex/actions/authentication/refreshToken.ts
@@ -67,7 +67,7 @@ export default async function refreshToken(
     value: vidRtCookie.value,
     httpOnly: true,
     maxAge: maxAge,
-    path: "/",
+    path: "/api/vtexid/refreshtoken/webstore",
     secure: true,
   });
 

--- a/vtex/utils/login/setLoginCookies.ts
+++ b/vtex/utils/login/setLoginCookies.ts
@@ -31,7 +31,7 @@ export default async function completeLogin(
           value: vidRtCookie.value,
           httpOnly: true,
           maxAge: maxAge,
-          path: "/",
+          path: "/api/vtexid/refreshtoken/webstore",
           secure: true,
         });
       }


### PR DESCRIPTION
The default path in VTEX requests for the refresh token is “/api/vtexid/refreshtoken/webstore,”
which can be seen in the cookie itself before setting

```
  {
    name: “vid_rt”,
    value: “.....”,
    expires: 2025-10-04T20:26:37.000Z,
    domain: “www.loja.com”,
    path: “/api/vtexid/refreshtoken/webstore”,
    secure: true,
    sameSite: “strict”,
    httpOnly: true
  }
```


The different path generates conflicts in other native routes, such as when using the default logout route /api/vtexid/pub/logout?scope=store.